### PR TITLE
Remove parsers declaration.

### DIFF
--- a/lib/parsers/ccda.js
+++ b/lib/parsers/ccda.js
@@ -2,8 +2,6 @@
  * ccda.js
  */
 
-var Parsers = {};
-
 Parsers.CCDA = (function () {
   
   var parseDate = Core.parseDate;


### PR DESCRIPTION
This declaration needed to be removed as it was clobbering the C32 parser when building with grunt.

I left the C32 declaration of `Parsers` around, so that holds both C32 & CCDA, otherwise the instance gets blown away with the version included from ccda.js.

Is `Parsers {}` required in (standalone) ccda.js for any reason? If so, I probably broke that.

The test suite is broken for me and I'm still coming back up to speed with familiarity of the project and js in general; so there might be a more general/correct way to solve this. (i.e. checking for existence, or moving both declarations to a centralized spot.)If there's a better way to solve this just let me know and I'm glad to fix.
