### PR TITLE
Parsing datetimes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,9 @@
     "ejs": true,
     "Generators": true,
     "Parsers": true,
-    "Renderers": true
+    "Renderers": true,
+    "describe": true,
+    "it": true,
+    "expect": true
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,10 @@ module.exports = function(grunt) {
           specs: "<%= bb.test %>/browser_specs/*_spec.js",
           vendor: ["<%= bb.test %>/helpers/*.js"]
         },
-        src: "<%= bb.build %>/bluebutton.js",
+        src: [
+          "<%= bb.build %>/bluebutton.js",
+          "<%= bb.src %>/documents.js"
+        ]
       },
       amd: {
         options: {
@@ -132,7 +135,10 @@ module.exports = function(grunt) {
           vendor: ["<%= bb.test %>/helpers/*.js"],
           template: require('grunt-template-jasmine-requirejs')
         },
-        src: "<%= bb.build %>/bluebutton.js",
+        src: [
+          "<%= bb.build %>/bluebutton.js",
+          "<%= bb.src %>/documents.js"
+        ]
       }
     },
     

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -47,20 +47,77 @@ var Documents = (function () {
    *     <low value="19630617120000"/>
    *     <high value="20110207100000"/>
    *   </effectiveTime>
-   * When latter, parseDate will not be given type `String`, but `null` and
-   * log the error "date is not a string".
+   * For the latter, parseDate will not be given type `String`
+   * and will return `null`.
    */
   var parseDate = function (str) {
     if (!str || typeof str !== 'string') {
-      // console.log("Error: date is not a string");
       return null;
     }
+
+    // Note: months start at 0 (so January is month 0)
+
+    // e.g., value="1999" translates to Jan 1, 1999
+    if (str.length === 4) {
+      return new Date(str, 0, 1);
+    }
+
     var year = str.substr(0, 4);
-    // months start at 0, because why not
+    // subtract 1 from the month since they're zero-indexed
     var month = parseInt(str.substr(4, 2), 10) - 1;
-    var day = str.substr(6, 2);
+    // days are not zero-indexed. If we end up with the day 0 or '',
+    // that will be equivalent to the last day of the previous month
+    var day = str.substr(6, 2) || 1;
+
+    // check for time info (the presence of at least hours and mins after the date)
+    if (str.length >= 12) {
+      var hour = str.substr(8, 2);
+      var min = str.substr(10, 2);
+      var secs = str.substr(12, 2);
+
+      // check for timezone info (the presence of chars after the seconds place)
+      if (str.length > 14) {
+        // _utcOffsetFromString will return 0 if there's no utc offset found.
+        var utcOffset = _utcOffsetFromString(str.substr(14));
+        // We subtract that offset from the local time to get back to UTC
+        // (e.g., if we're -480 mins behind UTC, we add 480 mins to get back to UTC)
+        min = _toInt(min) - utcOffset;
+      }
+
+      return new Date(Date.UTC(year, month, day, hour, min, secs));
+    }
+
     return new Date(year, month, day);
   };
+
+  // These regexes and the two functions below are copied from moment.js
+  // http://momentjs.com/
+  // https://github.com/moment/moment/blob/develop/LICENSE
+  var parseTimezoneChunker = /([\+\-]|\d\d)/gi;
+  var parseTokenTimezone = /Z|[\+\-]\d\d:?\d\d/gi; // +00:00 -00:00 +0000 -0000 or Z
+  function _utcOffsetFromString(string) {
+      string = string || '';
+      var possibleTzMatches = (string.match(parseTokenTimezone) || []),
+          tzChunk = possibleTzMatches[possibleTzMatches.length - 1] || [],
+          parts = (tzChunk + '').match(parseTimezoneChunker) || ['-', 0, 0],
+          minutes = +(parts[1] * 60) + _toInt(parts[2]);
+
+      return parts[0] === '+' ? minutes : -minutes;
+  }
+  function _toInt(argumentForCoercion) {
+      var coercedNumber = +argumentForCoercion,
+          value = 0;
+
+      if (coercedNumber !== 0 && isFinite(coercedNumber)) {
+          if (coercedNumber >= 0) {
+              value = Math.floor(coercedNumber);
+          } else {
+              value = Math.ceil(coercedNumber);
+          }
+      }
+
+      return value;
+  }
   
   
   /*
@@ -111,6 +168,15 @@ var Documents = (function () {
       country: country
     };
   };
+
+  // Node-specific code for unit tests
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      module.exports = {
+        parseDate: parseDate
+      };
+    }
+  }
   
   
   return {

--- a/spec/javascripts/amd_specs/bluebutton_spec.js
+++ b/spec/javascripts/amd_specs/bluebutton_spec.js
@@ -4,6 +4,8 @@ define(['../../../build/bluebutton'], function(BlueButton) {
     it("should exist", function() {
       expect(BlueButton).toBeDefined();
     });
+
+    runDateParsingTests(Documents);
     
   });
 });

--- a/spec/javascripts/browser_specs/bluebutton_spec.js
+++ b/spec/javascripts/browser_specs/bluebutton_spec.js
@@ -3,5 +3,7 @@ describe("BlueButton", function() {
   it("should be defined on window", function() {
     expect(window.BlueButton).toBeDefined();
   });
+
+  runDateParsingTests(Documents);
   
 });

--- a/spec/javascripts/fixtures/ccda/hl7_expected_ccda.xml
+++ b/spec/javascripts/fixtures/ccda/hl7_expected_ccda.xml
@@ -38,7 +38,7 @@
         
     </title>
     
-        <effectiveTime value="20050329" />
+        <effectiveTime value="20050329121504+0000" />
     
     <confidentialityCode code="N" displayName="Normal" codeSystem="2.16.840.1.113883.5.25"/>
     <languageCode code="en-US"/>
@@ -191,7 +191,7 @@
             <serviceEvent classCode="PCPR">
                 <effectiveTime>
                     
-                        <low value="20050329" />
+                        <low value="20050329121504+0000" />
                     
                     <high nullFlavor="UNK" />
                 </effectiveTime>
@@ -909,7 +909,7 @@
                                                 <td>Pneumonia</td>
                                                 <td>233604007</td>
                                                 <td></td>
-                                                <td>02/28/1998</td>
+                                                <td>03/01/1998</td>
                                                 <td>Active</td>
                                             </tr>
                                         
@@ -929,7 +929,7 @@
                                         <code nullFlavor="NA"/>
                                         <statusCode code="completed"/>
                                         <effectiveTime>
-                                            <low value="19980228" />
+                                            <low value="19980301" />
                                             <high value="20110103" />
                                         </effectiveTime>
                                         <entryRelationship typeCode="SUBJ">
@@ -940,7 +940,7 @@
                                                 <code code="409586006" codeSystem="2.16.840.1.113883.6.96" displayName="Complaint"/>
                                                 <statusCode code="completed"/>
                                                 <effectiveTime>
-                                                    <low value="19980228" />
+                                                    <low value="19980301" />
                                                 </effectiveTime>
                                                 <value xsi:type="CD" displayName="Pneumonia" code="233604007" codeSystem="2.16.840.1.113883.6.96" />
                                                 <entryRelationship typeCode="REFR">
@@ -1097,7 +1097,7 @@
                                                     <td>g/dl</td>
                                                                                                             <td></td>
                                                     
-                                                    <td>03/23/2000</td>
+                                                    <td>2000-03-23T14:30:00Z</td>
                                                 </tr>
                                             
                                                 <tr>
@@ -1107,7 +1107,7 @@
                                                     <td>10+3/ul</td>
                                                                                                             <td>4.3 to 10.8</td>
                                                     
-                                                    <td>03/23/2000</td>
+                                                    <td>2000-03-23T14:30:00Z</td>
                                                 </tr>
                                             
                                                 <tr>
@@ -1117,7 +1117,7 @@
                                                     <td>10+3/ul</td>
                                                                                                             <td>150 to 350</td>
                                                     
-                                                    <td>03/23/2000</td>
+                                                    <td>2000-03-23T14:30:00Z</td>
                                                 </tr>
                                             
                                         
@@ -1149,7 +1149,7 @@
                                             <code displayName="HGB" code="30313-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" >
                                             </code>
                                             <statusCode code="completed"/>
-                                            <effectiveTime value="20000323" />
+                                            <effectiveTime value="20000323143000+0000" />
                                             
                                                 <value xsi:type="PQ"
                                                     value="13.2"
@@ -1179,7 +1179,7 @@
                                             <code displayName="WBC" code="33765-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" >
                                             </code>
                                             <statusCode code="completed"/>
-                                            <effectiveTime value="20000323" />
+                                            <effectiveTime value="20000323143000+0000" />
                                             
                                                 <value xsi:type="PQ"
                                                     value="6.7"
@@ -1209,7 +1209,7 @@
                                             <code displayName="PLT" code="26515-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" >
                                             </code>
                                             <statusCode code="completed"/>
-                                            <effectiveTime value="20000323" />
+                                            <effectiveTime value="20000323143000+0000" />
                                             
                                                 <value xsi:type="PQ"
                                                     value="123"
@@ -1337,7 +1337,7 @@
                                                 <td>Influenza virus vaccine</td>
                                                 <td>CVX</td>
                                                 <td>88</td>
-                                                <td>10/31/1999</td>
+                                                <td>11/01/1999</td>
                                             </tr>
                                         
                                             <tr>
@@ -1375,7 +1375,7 @@
                                         <!--  ********   Immunization activity template    ******** -->
                                         <id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
                                         <statusCode code="completed"/>
-                                        <effectiveTime xsi:type="IVL_TS" value="19991031" />
+                                        <effectiveTime xsi:type="IVL_TS" value="19991101" />
                                         <routeCode displayName="Intramuscular injection" code="IM" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration" />
                                                                                     <doseQuantity nullFlavor="UNK"/>
                                                                                 <consumable>

--- a/spec/javascripts/fixtures/json/allscripts_ccda_expected_output.json
+++ b/spec/javascripts/fixtures/json/allscripts_ccda_expected_output.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "date": "07/18/2013",
+    "date": "2013-07-18T15:18:36Z",
     "author": {
       "name": {
         "prefix": null,
@@ -273,14 +273,14 @@
   ],
   "functional_statuses": [
     {
-      "date": "07/11/2013",
+      "date": "2013-07-11T04:00:00Z",
       "name": "No impairment",
       "code": "66557003",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": "SNOMED CT"
     },
     {
-      "date": "07/11/2013",
+      "date": "2013-07-11T04:00:00Z",
       "name": "No impairment",
       "code": "66557003",
       "code_system": "2.16.840.1.113883.6.96",
@@ -289,7 +289,7 @@
   ],
   "immunizations": [
     {
-      "date": "08/15/2010",
+      "date": "2010-08-15T04:00:00Z",
       "product": {
         "name": "Influenza A (H1N1) Monoval PF Intramuscular Suspension",
         "code": "126",
@@ -347,7 +347,7 @@
       "code_system_name": "CPT",
       "tests": [
         {
-          "date": "07/11/2013",
+          "date": "2013-07-11T00:27:00Z",
           "name": "Carbon Dioxide",
           "value": 25.2,
           "unit": "mmol/L",

--- a/spec/javascripts/fixtures/json/c32_expected_browser_output.json
+++ b/spec/javascripts/fixtures/json/c32_expected_browser_output.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "date": "11/10/2009",
+    "date": "2009-11-10T13:09:45Z",
     "author": {
       "name": {
         "prefix": null,
@@ -258,7 +258,7 @@
   "functional_statuses": [],
   "immunizations": [
     {
-      "date": "10/31/1999",
+      "date": "11/01/1999",
       "product": {
         "name": "Influenza virus vaccine",
         "code": "88",
@@ -399,10 +399,10 @@
       "code": "43789009",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": null,
-      "date": "03/23/2000",
+      "date": "2000-03-23T14:30:00Z",
       "tests": [
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "HGB",
           "value": 13.2,
           "unit": "g/dl",
@@ -418,7 +418,7 @@
           }
         },
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "WBC",
           "value": 6.7,
           "unit": "10+3/ul",
@@ -434,7 +434,7 @@
           }
         },
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "PLT",
           "value": 123,
           "unit": "10+3/ul",
@@ -456,10 +456,10 @@
       "code": "20109005",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": "SNOMED CT",
-      "date": "04/06/2000",
+      "date": "2000-04-06T13:00:00Z",
       "tests": [
         {
-          "date": "04/06/2000",
+          "date": "2000-04-06T13:00:00Z",
           "name": "NA",
           "value": 140,
           "unit": "meq/l",
@@ -475,7 +475,7 @@
           }
         },
         {
-          "date": "04/06/2000",
+          "date": "2000-04-06T13:00:00Z",
           "name": "K",
           "value": 4,
           "unit": "meq/l",
@@ -491,7 +491,7 @@
           }
         },
         {
-          "date": "04/06/2000",
+          "date": "2000-04-06T13:00:00Z",
           "name": "CL",
           "value": 102,
           "unit": "meq/l",
@@ -507,7 +507,7 @@
           }
         },
         {
-          "date": "04/06/2000",
+          "date": "2000-04-06T13:00:00Z",
           "name": "HCO3",
           "value": 35,
           "unit": "meq/l",
@@ -528,7 +528,7 @@
   "medications": [
     {
       "date_range": {
-        "start": "Invalid Date",
+        "start": "01/01/2005",
         "end": null
       },
       "text": null,
@@ -845,7 +845,7 @@
   "problems": [
     {
       "date_range": {
-        "start": "Invalid Date",
+        "start": "01/01/1950",
         "end": null
       },
       "name": "Asthma",
@@ -941,7 +941,7 @@
   ],
   "procedures": [
     {
-      "date": "Invalid Date",
+      "date": "01/01/1998",
       "name": "Total hip replacement",
       "code": "52734007",
       "code_system": "2.16.840.1.113883.6.96",

--- a/spec/javascripts/fixtures/json/emerge_ccda_expected_output.json
+++ b/spec/javascripts/fixtures/json/emerge_ccda_expected_output.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "date": "04/16/2014",
+    "date": "2014-04-16T11:54:39Z",
     "author": {
       "name": {
         "prefix": null,
@@ -60,7 +60,7 @@
   "allergies": [
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "name": null,
@@ -89,7 +89,7 @@
     },
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "name": null,
@@ -118,7 +118,7 @@
     },
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "name": null,
@@ -158,7 +158,7 @@
       ],
       "family": "Maxwell"
     },
-    "dob": "08/05/1940",
+    "dob": "1940-08-05T12:00:00Z",
     "gender": "female",
     "marital_status": "married",
     "address": {
@@ -222,7 +222,7 @@
   },
   "encounters": [
     {
-      "date": "03/31/2010",
+      "date": "2010-03-31T10:00:00Z",
       "name": "Office/outpatient visit, est",
       "code": "99212",
       "code_system": "2.16.840.1.113883.6.12",
@@ -262,7 +262,7 @@
       }
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "name": "Office/outpatient visit, est",
       "code": "99213",
       "code_system": "2.16.840.1.113883.6.12",
@@ -297,7 +297,7 @@
       }
     },
     {
-      "date": "06/08/2010",
+      "date": "2010-06-08T10:00:00Z",
       "name": "Initial inpatient consult",
       "code": "99251",
       "code_system": "2.16.840.1.113883.6.12",
@@ -332,7 +332,7 @@
       }
     },
     {
-      "date": "06/25/2010",
+      "date": "2010-06-25T10:00:00Z",
       "name": "Office/outpatient visit, est",
       "code": "99212",
       "code_system": "2.16.840.1.113883.6.12",
@@ -361,7 +361,7 @@
       }
     },
     {
-      "date": "10/27/2010",
+      "date": "2010-10-27T10:00:00Z",
       "name": "Office/outpatient visit, est",
       "code": "99213",
       "code_system": "2.16.840.1.113883.6.12",
@@ -393,7 +393,7 @@
   "functional_statuses": [],
   "immunizations": [
     {
-      "date": "10/27/2010",
+      "date": "2010-10-27T10:00:00Z",
       "product": {
         "name": "Influenza, high dose seasonal",
         "code": "135",
@@ -426,7 +426,7 @@
       }
     },
     {
-      "date": "10/27/2010",
+      "date": "2010-10-27T10:00:00Z",
       "product": {
         "name": "pneumococcal conjugate PCV 7",
         "code": "100",
@@ -469,7 +469,7 @@
       "code_system_name": "SNOMED-CT",
       "tests": [
         {
-          "date": "03/31/2010",
+          "date": "2010-03-31T10:00:00Z",
           "name": "HDLc SerPl-sCnc",
           "value": 55,
           "unit": "mg/dL",
@@ -485,7 +485,7 @@
           }
         },
         {
-          "date": "03/31/2010",
+          "date": "2010-03-31T10:00:00Z",
           "name": "LDLc SerPl-mCnc",
           "value": 85,
           "unit": "mg/dL",
@@ -501,7 +501,7 @@
           }
         },
         {
-          "date": "03/31/2010",
+          "date": "2010-03-31T10:00:00Z",
           "name": "Cholest SerPl-mCnc",
           "value": 165,
           "unit": "mg/dL",
@@ -517,7 +517,7 @@
           }
         },
         {
-          "date": "03/31/2010",
+          "date": "2010-03-31T10:00:00Z",
           "name": "Trigl SerPl Calc-mCnc",
           "value": 125,
           "unit": "mg/dL",
@@ -538,7 +538,7 @@
   "medications": [
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "text": null,
@@ -601,7 +601,7 @@
     },
     {
       "date_range": {
-        "start": "06/10/2010",
+        "start": "2010-06-10T10:00:00Z",
         "end": null
       },
       "text": null,
@@ -666,7 +666,7 @@
   "problems": [
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "name": "Essential hypertension",
@@ -685,7 +685,7 @@
     },
     {
       "date_range": {
-        "start": "03/31/2010",
+        "start": "2010-03-31T10:00:00Z",
         "end": null
       },
       "name": "Low back pain",
@@ -704,7 +704,7 @@
     },
     {
       "date_range": {
-        "start": "06/06/2010",
+        "start": "2010-06-06T10:00:00Z",
         "end": null
       },
       "name": "Neoplasm of colon",
@@ -723,7 +723,7 @@
     },
     {
       "date_range": {
-        "start": "06/08/2010",
+        "start": "2010-06-08T10:00:00Z",
         "end": null
       },
       "name": "Acute renal failure syndrome",
@@ -742,7 +742,7 @@
     },
     {
       "date_range": {
-        "start": "06/12/2010",
+        "start": "2010-06-12T10:00:00Z",
         "end": null
       },
       "name": "T3: Colon/rectum tumor invades through the muscularis propria into the subserosa or the nonperitonealized pericolic or perirectal soft tissues",
@@ -762,7 +762,7 @@
   ],
   "procedures": [
     {
-      "date": "03/31/2010",
+      "date": "2010-03-31T10:00:00Z",
       "name": "X-ray exam of spine",
       "code": "72010",
       "code_system": "2.16.840.1.113883.6.12",
@@ -787,7 +787,7 @@
       }
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "name": "Diagnostic colonoscopy",
       "code": "45378",
       "code_system": "2.16.840.1.113883.6.12",
@@ -812,7 +812,7 @@
       }
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "name": "PET img whbd ring dx colorec",
       "code": "G0213",
       "code_system": "2.16.840.1.113883.6.13",
@@ -837,7 +837,7 @@
       }
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "name": "Medical nutrition, indiv, in",
       "code": "97802",
       "code_system": "2.16.840.1.113883.6.12",
@@ -862,7 +862,7 @@
       }
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "name": "Exercise class",
       "code": "S9451",
       "code_system": "2.16.840.1.113883.6.13",
@@ -896,7 +896,7 @@
   },
   "vitals": [
     {
-      "date": "03/31/2010",
+      "date": "2010-03-31T10:00:00Z",
       "results": [
         {
           "name": "BP Diastolic",
@@ -925,7 +925,7 @@
       ]
     },
     {
-      "date": "06/06/2010",
+      "date": "2010-06-06T10:00:00Z",
       "results": [
         {
           "name": "BMI",
@@ -938,7 +938,7 @@
       ]
     },
     {
-      "date": "10/27/2010",
+      "date": "2010-10-27T10:00:00Z",
       "results": [
         {
           "name": "BP Diastolic",

--- a/spec/javascripts/fixtures/json/hl7_ccda_expected_output.json
+++ b/spec/javascripts/fixtures/json/hl7_ccda_expected_output.json
@@ -1,10 +1,12 @@
 {
   "document": {
-    "date": "03/29/2005",
+    "date": "2005-03-29T12:15:04Z",
     "author": {
       "name": {
         "prefix": null,
-        "given": ["Henry"],
+        "given": [
+          "Henry"
+        ],
         "family": "Seven"
       },
       "address": {
@@ -24,7 +26,9 @@
       {
         "name": {
           "prefix": "Dr.",
-          "given": ["Pseudo"],
+          "given": [
+            "Pseudo"
+          ],
           "family": "Physician-1"
         },
         "phone": {
@@ -41,7 +45,9 @@
       {
         "name": {
           "prefix": "Dr.",
-          "given": ["Pseudo"],
+          "given": [
+            "Pseudo"
+          ],
           "family": "Physician-3"
         },
         "phone": {
@@ -78,8 +84,8 @@
       "code": "416098002",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": "SNOMED CT",
-      "severity": "Moderate to severe",
       "status": "Active",
+      "severity": "Moderate to severe",
       "reaction": {
         "name": "Hives",
         "code": "247472004",
@@ -107,8 +113,8 @@
       "code": "416098002",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": "SNOMED CT",
-      "severity": "Moderate to severe",
       "status": "Active",
+      "severity": "Moderate to severe",
       "reaction": {
         "name": "Wheezing",
         "code": "56018004",
@@ -136,8 +142,8 @@
       "code": "416098002",
       "code_system": "2.16.840.1.113883.6.96",
       "code_system_name": "SNOMED CT",
-      "severity": "Moderate to severe",
       "status": "Active",
+      "severity": "Moderate to severe",
       "reaction": {
         "name": "Nausea",
         "code": "73879007",
@@ -269,11 +275,13 @@
       "code_system": "2.16.840.1.113883.6.12",
       "code_system_name": "CPT",
       "code_system_version": "4",
-      "findings": [{
-        "name": "Bronchitis",
-        "code": "32398004",
-        "code_system": "2.16.840.1.113883.6.96"
-      }],
+      "findings": [
+        {
+          "name": "Bronchitis",
+          "code": "32398004",
+          "code_system": "2.16.840.1.113883.6.96"
+        }
+      ],
       "translation": {
         "name": "Ambulatory",
         "code": "AMB",
@@ -287,21 +295,21 @@
         "code_system_name": "SNOMED CT"
       },
       "location": {
-        "organization": "General Acute Care Hospital",
         "street": [
           "17 Daws Rd."
         ],
         "city": "Blue Bell",
         "state": "MA",
         "zip": "02368",
-        "country": "US"
+        "country": "US",
+        "organization": "General Acute Care Hospital"
       }
     }
   ],
   "functional_statuses": [],
   "immunizations": [
     {
-      "date": "10/31/1999",
+      "date": "11/01/1999",
       "product": {
         "name": "Influenza virus vaccine",
         "code": "88",
@@ -443,7 +451,7 @@
       "code_system_name": "SNOMED CT",
       "tests": [
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "HGB",
           "value": 13.2,
           "unit": "g/dl",
@@ -459,7 +467,7 @@
           }
         },
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "WBC",
           "value": 6.7,
           "unit": "10+3/ul",
@@ -475,7 +483,7 @@
           }
         },
         {
-          "date": "03/23/2000",
+          "date": "2000-03-23T14:30:00Z",
           "name": "PLT",
           "value": 123,
           "unit": "10+3/ul",
@@ -561,7 +569,7 @@
   "problems": [
     {
       "date_range": {
-        "start": "02/28/1998",
+        "start": "03/01/1998",
         "end": "01/03/2011"
       },
       "name": "Pneumonia",
@@ -591,7 +599,6 @@
         "code_system": null
       },
       "performer": {
-        "organization": null,
         "street": [
           "17 Daws Rd."
         ],
@@ -599,6 +606,7 @@
         "state": "MA",
         "zip": "02368",
         "country": "US",
+        "organization": null,
         "phone": null
       },
       "device": {
@@ -618,7 +626,6 @@
         "code_system": null
       },
       "performer": {
-        "organization": null,
         "street": [
           "17 Daws Rd."
         ],
@@ -626,6 +633,7 @@
         "state": "MA",
         "zip": "02368",
         "country": "US",
+        "organization": null,
         "phone": null
       },
       "device": {
@@ -645,7 +653,6 @@
         "code_system": null
       },
       "performer": {
-        "organization": null,
         "street": [
           "17 Daws Rd."
         ],
@@ -653,6 +660,7 @@
         "state": "MA",
         "zip": "02368",
         "country": "US",
+        "organization": null,
         "phone": null
       },
       "device": {
@@ -662,6 +670,13 @@
       }
     }
   ],
+  "smoking_status": {
+    "date": null,
+    "name": null,
+    "code": null,
+    "code_system": null,
+    "code_system_name": null
+  },
   "vitals": [
     {
       "date": "11/14/1999",
@@ -721,12 +736,5 @@
         }
       ]
     }
-  ],
-  "smoking_status": {
-    "date": null,
-    "name": null,
-    "code": null,
-    "code_system": null,
-    "code_system_name": null
-  }
+  ]
 }

--- a/spec/javascripts/helpers/shared_spec.js
+++ b/spec/javascripts/helpers/shared_spec.js
@@ -169,10 +169,63 @@ var runJsonTests = function(expectedOutput, expectedType, bb) {
 
 };
 
+var runDateParsingTests = function(Documents) {
+  describe('parseDate', function() {
+    var parseDate = Documents.parseDate;
+
+    // on the left: the input you want to test
+    // on the right: an ISO-8601 date-time (UTC) or a MM/DD/YYYY date-time (local time)
+    var assertEquivalency = function(inputStr, expectedStr) {
+      var parsed = parseDate(inputStr).getTime();
+      var expected = (new Date(expectedStr)).getTime();
+      expect(parsed).toEqual(expected);
+    };
+
+    it('should parse year only', function() {
+      assertEquivalency('1999', '01/01/1999 00:00:00');
+    });
+
+    it('should parse year + month', function() {
+      assertEquivalency('199907', '07/01/1999 00:00:00');
+    });
+
+    it('should parse year + month + day', function() {
+      assertEquivalency('19990704', '07/04/1999 00:00:00');
+    });
+
+    it('should parse standard CCDA date', function() {
+      assertEquivalency('20140416115439', '2014-04-16T11:54:39Z');
+    });
+
+    it('should parse CCDA date + positive timezone', function() {
+      assertEquivalency('20140416115439+0700', '2014-04-16T04:54:39Z');
+    });
+
+    it('should parse CCDA date + negative timezone', function() {
+      assertEquivalency('20140416115439-0500', '2014-04-16T16:54:39Z');
+    });
+
+    it('should parse CCDA date + UTC timezone', function() {
+      assertEquivalency('20140416115439Z', '2014-04-16T11:54:39Z');
+    });
+
+    it('should parse CCDA date + timezone + millis', function() {
+      assertEquivalency('20101026091700.000-0500', '2010-10-26T14:17:00Z');
+    });
+
+    it('should parse totally invalid date as NaN', function() {
+      expect(parseDate('gobbledigook').getTime()).toBeNaN();
+    });
+  });
+};
+
 // Node-specific code
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = runJsonTests;
+    module.exports = {
+      runJsonTests: runJsonTests,
+      runDateParsingTests: runDateParsingTests
+    };
     var _ = require('underscore');
   }
 }

--- a/spec/javascripts/node_specs/bluebutton_spec.js
+++ b/spec/javascripts/node_specs/bluebutton_spec.js
@@ -1,9 +1,13 @@
-var BlueButton = require('../../../build/bluebutton');
+var BlueButton = require('../../../build/bluebutton'),
+    runDateParsingTests = require('../helpers/shared_spec').runDateParsingTests,
+    Documents = require('../../../lib/documents');
 
 describe("BlueButton", function() {
   
   it("should exist", function() {
     expect(BlueButton).toBeDefined();
   });
-  
+
+  runDateParsingTests(Documents);
+
 });

--- a/spec/javascripts/node_specs/c32_spec.js
+++ b/spec/javascripts/node_specs/c32_spec.js
@@ -1,14 +1,16 @@
 var fs = require('fs'),
     path = require('path'),
-    runJsonTests = require('../helpers/shared_spec'),
+    runJsonTests = require('../helpers/shared_spec').runJsonTests,
     BlueButton = require('../../../build/bluebutton');
+
+var expectedOutput;
 
 describe('C32', function() {
   var record = fs.readFileSync(path.resolve(__dirname,
     '../fixtures/c32/HITSP_C32v2.5_Rev6_16Sections_Entries_MinimalErrors.xml'), 'utf-8');
   var bb = BlueButton(record);
 
-  var expectedOutput = JSON.parse(fs.readFileSync(path.resolve(__dirname,
+  expectedOutput = JSON.parse(fs.readFileSync(path.resolve(__dirname,
     '../fixtures/json/c32_expected_browser_output.json'), 'utf-8'));
 
   /* There are several dates near Daylight Saving time.
@@ -53,13 +55,14 @@ describe('C32', function() {
 
   // the tests are defined in helpers/shared_spec.js
   runJsonTests(expectedOutput, 'c32', bb);
+});
 
+describe('C32 with HL7 IDs', function() {
   // We're also going to test a slight variant of the file above,
   // which uses only old HL7 CCD tags, instead of the HITSP section tags
   // to make sure we're resilient to that
-  record = fs.readFileSync(path.resolve(__dirname,
+  var record = fs.readFileSync(path.resolve(__dirname,
     '../fixtures/c32/HITSP_C32_with_HL7_IDs.xml'), 'utf-8');
-  bb = BlueButton(record);
+  var bb = BlueButton(record);
   runJsonTests(expectedOutput, 'c32', bb);
-
 });

--- a/spec/javascripts/node_specs/ccda_spec.js
+++ b/spec/javascripts/node_specs/ccda_spec.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     path = require('path'),
-    runJsonTests = require('../helpers/shared_spec'),
+    runJsonTests = require('../helpers/shared_spec').runJsonTests,
     BlueButton = require('../../../build/bluebutton');
 
 describe('HL7 CCDA', function() {


### PR DESCRIPTION
This change started by including moment.js, using it to update the new expected values, and then extending parseDate until it could match the output of moment.js, at least for the sample files in our unit tests. It also adds unit tests to parseDate, so that we can add specific test cases as we find new deficiencies.