### PR TITLE
Run C32 results through procedures parser too, fixes #73

### DIFF
--- a/lib/documents/c32.js
+++ b/lib/documents/c32.js
@@ -70,8 +70,9 @@ Documents.C32 = (function () {
         if (el.isEmpty()) {
           el = this.template('2.16.840.1.113883.10.20.1.12');
         }
-        el.entries = entries;
-        return el;
+        el2 = this.template('2.16.840.1.113883.3.88.11.83.122'); // scan results for procedures too
+        el.entries, el2.entries = entries;
+        return el, el2;
       case 'vitals':
         el = this.template('2.16.840.1.113883.3.88.11.83.119');
         if (el.isEmpty()) {


### PR DESCRIPTION
This runs both Results and Procedures through the C32 Procedures parser, because as #73 mentions sometimes Results sections contain Procedures too.

What a world.