### PR TITLE
Example File Clarification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ myRecord.source  // The parsed source data with added querying methods
 myRecord.data    // The final parsed document data
 ```
 
+Note: Many of the example health records posted here are missing the XML declaration required by the BlueButton.js parser. If you are experiencing errors with CCDA parsing, add ```XML <?xml version="1.0" encoding="UTF-8" standalone="no" ?>``` as the first line of your CCDA file. 
+
 ## Detailed Documentation
 
 See http://www.bluebuttonjs.com/docs/ for an explanation of the data sections, much more detailed sample code, instructions on how to generate a build, etc.


### PR DESCRIPTION
I think this README change should be added because the several of the example CCDA documents provided are rejected as not XML, even though the documents are considered valid by online XML validators. This led to some confusion, but I figured out that the parser code requires the first five characters of the CCDA document to be <?xml. I hope this helps others use the tools.