### PR TITLE
Downgrade grunt dependency from 1.0.0 to 0.4.0 to prevent grunt-contrib failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bluebutton",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "BlueButton.js helps developers navigate complex health data with ease.",
   "keywords": [
     "bb",
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "bower": "*",
-    "grunt": "*",
+    "grunt": "~0.4.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-copy": "~0.5.0",
@@ -67,5 +67,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "licenses": ["MIT"]
+  "licenses": [
+    "MIT"
+  ]
 }


### PR DESCRIPTION
Grunt released v1.0.0 April 4th, this commit updates the package.json to prevent grunt.1.0.0 from downloading since other grunt-contrib packages don't support grunt.1.0.0.

```
npm ERR! Darwin 13.4.0

npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v4.3.1
npm ERR! npm  v2.14.12
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package grunt@1.0.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-contrib-copy@0.5.0 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-clean@0.5.0 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-concat@0.4.0 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-watch@0.6.1 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-jshint@0.10.0 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-uglify@0.4.1 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-contrib-jasmine@0.5.3 wants grunt@~0.4.0
```